### PR TITLE
Remove args.loss_type in NGCF.py

### DIFF
--- a/NGCF/NGCF.py
+++ b/NGCF/NGCF.py
@@ -531,7 +531,7 @@ if __name__ == '__main__':
     f = open(save_path, 'a')
 
     f.write(
-        'embed_size=%d, lr=%.4f, layer_size=%s, node_dropout=%s, mess_dropout=%s, regs=%s, loss_type=%s, adj_type=%s\n\t%s\n'
-        % (args.embed_size, args.lr, args.layer_size, args.node_dropout, args.mess_dropout, args.regs, args.loss_type,
+        'embed_size=%d, lr=%.4f, layer_size=%s, node_dropout=%s, mess_dropout=%s, regs=%s, adj_type=%s\n\t%s\n'
+        % (args.embed_size, args.lr, args.layer_size, args.node_dropout, args.mess_dropout, args.regs,
            args.adj_type, final_perf))
     f.close()


### PR DESCRIPTION
Try to fix a bug. There is not an argument named loss_type in parser.py. 